### PR TITLE
Bias the data relative to a chosen currency

### DIFF
--- a/client/main.html
+++ b/client/main.html
@@ -13,6 +13,7 @@
     </div>
 
     <div class="ui one wide column">
+      <label for="reactive">Days</label>
       <select id="reactive">
         <option value="0">0</option>
         <option value="10">10</option>
@@ -27,6 +28,15 @@
         <option value="100">100</option>
         <option value="120">120</option>
         <option value="140">140</option>
+      </select>
+
+      <br/>
+      <label for="bias">Bias</label>
+      <select id="bias">
+        <option value="none" selected></option>
+      {{#each currency in currencies}}
+        <option value="{{currency.name}}">{{currency.name}}</option>
+      {{/each}}
       </select>
     </div>
 

--- a/client/main.js
+++ b/client/main.js
@@ -1,6 +1,8 @@
 // Computed collection. See seriesData publication.
 SeriesData = new Mongo.Collection('seriesData');
 
+bias = new ReactiveVar("none");
+
 Template.body.onCreated(function() {
   this.limit = new ReactiveVar(20);
 });
@@ -37,6 +39,9 @@ Template.body.helpers({
   },
   limit() {
     return Template.instance().limit.get();
+  },
+  currencies() {
+    return Currencies.find();
   }
 });
 
@@ -44,8 +49,36 @@ Template.body.events({
   'change #reactive': function (event, template) {
     var limit = $(event.target).val();
     template.limit.set(limit);
+  },
+  'change #bias': function(event) {
+    bias.set($(event.target).val());
   }
 });
+
+seriesData = function(series) {
+  if (bias.get() === "none")
+    return series;
+  var biasSeries;
+  _.forEach(series, function(oneSeries) {
+    if (oneSeries.name === bias.get()) {
+      biasSeries = oneSeries;
+    }
+  });
+  var biasedSeries = [];
+  _.forEach(series, function(oneSeries) {
+    el = {
+      _id: oneSeries._id,
+      currentValue: oneSeries.currentValue,
+      name: oneSeries.name,
+      data: []
+    }
+    _.forEach(oneSeries.data, function(value, n) {
+      el.data[n] = value-biasSeries.data[n];
+    });
+    biasedSeries.push(el);
+  });
+  return biasedSeries;
+}
 
 // Function to draw the area chart
 
@@ -53,13 +86,17 @@ function builtArea(series) {
   _.forEach(series, function(oneSeries) {
     let lastDataValue = numeral(oneSeries.data[oneSeries.data.length - 1])
       .format('0.00') + '%';
-      
+
     _.extend(oneSeries, {
       currentValue: lastDataValue});
   });
-  
+
+  titleText = 'Currency Growth'
+  if (bias.get() !== "none")
+    titleText = 'Currency Growth relative to '+bias.get()
+
   $('#container-area').highcharts({
-    title: {text: 'Currency Growth'},
+    title: {text: titleText},
     credits: {enabled: false},
     subtitle: {enabled: false},
     xAxis: {
@@ -102,6 +139,6 @@ function builtArea(series) {
       }
     },
 
-    series: series
+    series: seriesData(series)
   });
 }


### PR DESCRIPTION
Choosing a currency from the Bias select will put the currency on the zero line and adjust all of the currency gains/losses in the chart relative to it. Selecting the blank option on the Bias select restores the absolute currency gains/losses.
